### PR TITLE
Add config for multiprocessing connection pools

### DIFF
--- a/asset_tracking/config.py
+++ b/asset_tracking/config.py
@@ -112,6 +112,12 @@ class Settings(BaseSettings):
         )
 
     @property
+    def multiprocessing_connection_pools(self) -> bool:
+        if CONFIG.get("asset_tracking", "multiprocessing_connection_pools", fallback=False):
+            return CONFIG.getboolean("asset_tracking", "multiprocessing_connection_pools")
+        return False
+        
+    @property
     def require_all_attributes(self) -> List:
         required_attributes: List[str] = []
         required_attributes_str = None

--- a/asset_tracking/database/operations.py
+++ b/asset_tracking/database/operations.py
@@ -31,6 +31,8 @@ Session: ORMSession = sessionmaker(autocommit=False, autoflush=True, bind=engine
 @contextlib.contextmanager
 def get_db_session():
     """Get a database session."""
+    if SETTINGS.multiprocessing_connection_pools:
+        engine.dispose(close=False)
     db = Session()
     try:
         yield db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asset-tracking"
-version = "0.1.4"
+version = "0.1.5"
 description = "Enterprise asset tracking by hostname for rouge device detection."
 authors = ["Sean McFeely <mcfeelynaes@gmail.com>"]
 
@@ -32,3 +32,4 @@ line-length = 120
 
 [tool.poetry.scripts]
 asset-tracker = "asset_tracking.cli:main"
+


### PR DESCRIPTION
This configuration is needed for multi-process applications. Without the engine.dispose(close=False) call, child processes may either reuse or close connection pools that are already in use by others. This can create a race condition, leading to unexpected errors. 

For more information on handling connection pools with multiprocessing or os.fork, please refer to the SQLAlchemy documentation: https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork.